### PR TITLE
Add NullSec Linux to pentesting distributions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -500,6 +500,7 @@ The tools listed below are commonly used in penetration testing, and the tool ca
 * [BlackArch Linux](https://blackarch.org) - Arch Linux-based penetration testing distribution
 * [Parrot Security](https://parrotlinux.org) - The ultimate framework for your Cyber Security operations
 * [ArchStrike](https://archstrike.org) - Arch Linux respository for security professionals
+* [NullSec Linux](https://github.com/bad-antics/nullsec-linux) - Security distribution with 135+ tools: cloud, AI/ML, hardware, automotive pentesting. 4 architectures.
 
 ### Cyber Range
 


### PR DESCRIPTION
## Addition

Adding **NullSec Linux** to the Pentesting Distribution section.

### Features
- 135+ specialized security tools
- 5 editions: Standard, Cloud Pentest, AI/ML Security, Hardware Hacking, Automotive Security  
- 4 architectures: AMD64, ARM64, RISC-V, Apple Silicon

Repository: https://github.com/bad-antics/nullsec-linux