### PR TITLE
Add operant-mcp to Vulnerability Scanner section

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -148,7 +148,8 @@ The tools listed below are commonly used in penetration testing, and the tool ca
 * [osv-scanner](https://github.com/google/osv-scanner) - Vulnerability scanner written in Go which uses the data provided by https://osv.dev
 * [Afrog](https://github.com/zan8in/afrog) -  A Vulnerability Scanning Tools For Penetration Testing
 * [OpalOPC](https://opalopc.com/) -  A vulnerability and misconfiguration scanner for OPC UA applications
-* [ZeroThreat](https://zerothreat.ai/) - An Ai-Powered Web App & API Vulnerability Scanning and Pentesting Platform. 
+* [ZeroThreat](https://zerothreat.ai/) - An Ai-Powered Web App & API Vulnerability Scanning and Pentesting Platform.
+* [operant-mcp](https://github.com/operantlabs/operant-mcp) - Open-source MCP server providing 51 security testing tools across 19 modules (SQLi, XSS, CMDi, SSRF, path traversal, PCAP forensics, recon, memory forensics, malware analysis). Install via `npx operant-mcp`. ![](svg/Windows.svg)![](svg/linux.svg)![](svg/mac.svg)
 
 ### Web Applications
 


### PR DESCRIPTION
## Summary
- Adds [operant-mcp](https://github.com/operantlabs/operant-mcp) to the **Vulnerability Analysis > Vulnerability Scanner** section
- Open-source MCP server providing 51 security testing tools across 19 modules:
  - SQL injection (6 tools), XSS, command injection, SSRF, path traversal
  - PCAP/network forensics (8 tools), reconnaissance (7 tools)
  - Memory forensics (Volatility), malware document analysis, CloudTrail analysis
  - Authentication testing, CORS, clickjacking, NoSQL injection, deserialization, GraphQL introspection
- Cross-platform (Windows/Linux/macOS), install via `npx operant-mcp`
- MIT licensed, written in TypeScript