### PR TITLE
Add Domain Intelligence API to Information Gathering / Domain Name

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,6 +40,7 @@ The tools listed below are commonly used in penetration testing, and the tool ca
 * [whois](https://docs.microsoft.com/en-us/sysinternals/downloads/whois) - Windows Whois performs the registration record for the domain name or IP address that you specify. ![](svg/Windows.svg)
 * [DNSrecon-gui](https://github.com/micro-joan/DNSrecon-gui) - DNSrecon tool with GUI for Kali Linux
 * [Dnsx](https://github.com/projectdiscovery/dnsx) - dnsx is a fast and multi-purpose DNS toolkit allow to run multiple DNS queries of your choice with a list of user-supplied resolvers.
+* [Domain Intelligence API](https://github.com/osiris-technical-institute/domain-intelligence-api) - REST API aggregating WHOIS/RDAP, DNS records, SSL certificate inspection, subdomain enumeration (5 sources + always-on DNS bruteforce), and email security (SPF/DMARC/DKIM auto-probed across 29 selectors) for any domain in one call. MIT-licensed, free tier.
 
 #### Subdomain
 


### PR DESCRIPTION
Adding Domain Intelligence API — REST API for domain recon. Returns WHOIS/RDAP, DNS records, SSL certificate inspection, subdomain enumeration (5 parallel sources + always-on DNS bruteforce), and email security posture (SPF/DMARC/DKIM auto-probed across 29 selectors) in a single call. MIT-licensed, free tier. Source: https://github.com/osiris-technical-institute/domain-intelligence-api