### PR TITLE
Add DomScan to Information Gathering (Domain Name)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,6 +40,7 @@ The tools listed below are commonly used in penetration testing, and the tool ca
 * [whois](https://docs.microsoft.com/en-us/sysinternals/downloads/whois) - Windows Whois performs the registration record for the domain name or IP address that you specify. ![](svg/Windows.svg)
 * [DNSrecon-gui](https://github.com/micro-joan/DNSrecon-gui) - DNSrecon tool with GUI for Kali Linux
 * [Dnsx](https://github.com/projectdiscovery/dnsx) - dnsx is a fast and multi-purpose DNS toolkit allow to run multiple DNS queries of your choice with a list of user-supplied resolvers.
+* [DomScan](https://domscan.net) - Online domain intelligence for DNS, WHOIS/RDAP, SSL, subdomain discovery, typosquatting and valuation, with an API and MCP server.
 
 #### Subdomain
 


### PR DESCRIPTION
Adds **DomScan** (https://domscan.net), a domain intelligence service for DNS, WHOIS/RDAP, SSL/TLS, subdomain discovery, valuation and typosquatting (API and MCP server). Added to the most relevant section in the existing format.