### PR TITLE
Add ghscan tool to the Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -74,6 +74,7 @@ The tools listed below are commonly used in penetration testing, and the tool ca
 * [Gitrob](https://github.com/michenriksen/gitrob) - Reconnaissance tool for GitHub organizations. ![](svg/Windows.svg)![](svg/linux.svg)![](svg/mac.svg)
 * [GitGot](https://github.com/BishopFox/GitGot) Semi-automated, feedback-driven tool to rapidly search through troves of public data on GitHub for sensitive secrets.
 * [GitDump](https://github.com/Ebryx/GitDump) - A pentesting tool that dumps the source code from .git even when the directory traversal is disabled
+* [ghscan](https://github.com/m4gester-bitt/ghscan) - CLI tool that enumerates a GitHub org's members and their personal repos, then runs TruffleHog secret scans across both.
 
 #### SVN
 


### PR DESCRIPTION
ghscan enumerates a GitHub org's members and their personal repos then runs resumable TruffleHog secret scans across both covering exposure that org-only scans (like github-dorks) miss when secrets leak through employee personal repos rather than the org's own. (for legal use)